### PR TITLE
Add push notification consent banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,4 +18,5 @@
 //= require cookies_eu
 //= require load-image.all.min.js
 //= require cropper.js
+//= require js.cookie.js
 //= require_tree .

--- a/app/assets/javascripts/push_notification_handler.js
+++ b/app/assets/javascripts/push_notification_handler.js
@@ -1,0 +1,66 @@
+class PushNotificationConsentHandler {
+  constructor(options = {triggerEl: null, hideEl: null}) {
+    this.options = options;
+    if(!this.validOptions()) { return }
+    if(this.permissionDenied()) { return }
+    if(this.hasPushNotificationCookie()) { return }
+    this.init();
+  }
+
+  validOptions() {
+    return this.options.triggerEl !== null &&
+           this.options.hideEl !== null;
+  }
+
+  init() {
+    this.options.wrapperEl.style.display = 'block';
+
+    this.options.hideEl.addEventListener('click', this.hidePushNotifications.bind(this), false);
+    this.options.hideEl.addEventListener('click', this.clearCache, false);
+    this.options.neverShowEl.addEventListener('click', this.neverShowPushNotifications.bind(this), false);
+    this.options.neverShowEl.addEventListener('click', this.clearCache, false);
+
+    this.options.triggerEl.addEventListener('click', this.requestPushNotifications.bind(this), false);
+  }
+
+  hidePushNotifications() {
+    this.setPushNotificaitonCookie(false, 14);
+  }
+
+  neverShowPushNotifications() {
+    this.setPushNotificaitonCookie(false, 3650);
+  }
+
+  hasPushNotificationCookie() {
+    Cookies.get('push_notification_consented');
+  }
+
+  setPushNotificaitonCookie(value, daysToReset = 365) {
+    Cookies.set('push_notification_consented', value, { path: '/', expires: daysToReset });
+  }
+
+  clearCache() {
+    if(window.Turbolinks) {
+      window.Turbolinks.clearCache();
+    }
+  }
+
+  requestPushNotifications() {
+    Notification.requestPermission().then((result) => {
+      if (result === 'denied') {
+        this.setPushNotificaitonCookie(false, 1);
+        return;
+      }
+      if (result === 'default') {
+        console.log('The permission request was dismissed.');
+        return;
+      }
+      this.setPushNotificaitonCookie(true, 730);
+      this.clearCache();
+    })
+  }
+
+  permissionDenied() {
+    return Notification.permission === 'denied';
+  }
+}

--- a/app/controllers/welcome_page_controller.rb
+++ b/app/controllers/welcome_page_controller.rb
@@ -10,4 +10,7 @@ class WelcomePageController < ApplicationController
 
   def cookies_consent
   end
+
+  def push_notifications
+  end
 end

--- a/app/views/components/_push_notification_conent.html.erb
+++ b/app/views/components/_push_notification_conent.html.erb
@@ -1,0 +1,18 @@
+<% if logged_in? && cookies && cookies['push_notification_consented'] == nil %>
+  <div id="push-notification-consent-wrapper" class="alert alert-warning fade show" style="display: none" role="alert">
+    <a href="#" class="trigger" data-dismiss="alert">Click here</a> to enable push notifications.
+    <a href="<%= push_notifications_url %>">Learn more</a> |
+    <a class="never-show" data-dismiss="alert" aria-label="Close" href="#">never show</a> |
+    <a class="hide" data-dismiss="alert" aria-label="Close" href="#">hide</a>
+  </div>
+  <script>
+    (function () {
+      new PushNotificationConsentHandler({
+        wrapperEl: document.querySelector('#push-notification-consent-wrapper'),
+        triggerEl: document.querySelector('#push-notification-consent-wrapper .trigger'),
+        hideEl: document.querySelector('#push-notification-consent-wrapper .hide'),
+        neverShowEl: document.querySelector('#push-notification-consent-wrapper .never-show')
+      });
+    })();
+  </script>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,7 @@
 <div class="container-after-top-fixed container">
   <%= render 'cookies_eu/consent_banner', link: '/cookies' %>
   <div class="flash-message-container row justify-content-center">
+    <%= render('components/push_notification_conent') %>
     <% flash.each do |message_type, message| %>
       <div class="col-6 alert alert-info alert-<%= message_type %> alert-dismissible fade show" role="alert">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">

--- a/app/views/welcome_page/push_notifications.html.erb
+++ b/app/views/welcome_page/push_notifications.html.erb
@@ -1,0 +1,14 @@
+<h1>Push Notifications</h1>
+
+<p>
+  We are passionate about creating engaging and customized experiences for everyoune using our service. We use all of
+  the information we have to help us provide and support our communication services. We are able to deliver our
+  services, personalize content, and make suggestions for you by using this information to understand how you use and
+  interact with our services, and the people or things you’re connected to and interested in; both on and off our
+  platform. We also use information to provide suggestions to you. For example, we are able to suggest like-minded
+  professionals to converse, connect, and meet with. When we have location information, we use it to tailor our services
+  for you and others. Like helping you to see other filtered profiles in your proximity range; as well as find other
+  relevant social interactions happening around you. We will utilise learning algorithms, conduct surveys and research,
+  test features in development, and analyze the information, evaluate and improve your overall experience on our
+  platform. As well as develop new products or features, and conduct audits and troubleshooting activities.
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
 
   get 'profile', to: 'profile#show'
 
+  get '/push_notifications', to: 'welcome_page#push_notifications'
   get '/cookies', to: 'welcome_page#cookies_consent'
   get 'sessions/new'
   get 'sessions/logout_success'

--- a/vendor/assets/javascript/js.cookie.js
+++ b/vendor/assets/javascript/js.cookie.js
@@ -1,0 +1,162 @@
+/*!
+ * JavaScript Cookie v2.2.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	var registeredInModuleLoader;
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
+		module.exports = factory();
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					attributes.expires = new Date(new Date() * 1 + attributes.expires * 864e+5);
+				}
+
+				// We're using "expires" because "max-age" is not supported by IE
+				attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+				try {
+					var result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				value = converter.write ?
+					converter.write(value, key) :
+					encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+
+				key = encodeURIComponent(String(key))
+					.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent)
+					.replace(/[\(\)]/g, escape);
+
+				var stringifiedAttributes = '';
+				for (var attributeName in attributes) {
+					if (!attributes[attributeName]) {
+						continue;
+					}
+					stringifiedAttributes += '; ' + attributeName;
+					if (attributes[attributeName] === true) {
+						continue;
+					}
+
+					// Considers RFC 6265 section 5.2:
+					// ...
+					// 3.  If the remaining unparsed-attributes contains a %x3B (";")
+					//     character:
+					// Consume the characters of the unparsed-attributes up to,
+					// not including, the first %x3B (";") character.
+					// ...
+					stringifiedAttributes += '=' + attributes[attributeName].split(';')[0];
+				}
+
+				return (document.cookie = key + '=' + value + stringifiedAttributes);
+			}
+
+			// Read
+
+			var jar = {};
+			var decode = function (s) {
+				return s.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);
+			};
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all.
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (!this.json && cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = decode(parts[0]);
+					cookie = (converter.read || converter)(cookie, name) ||
+						decode(cookie);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					jar[name] = cookie;
+
+					if (key === name) {
+						break;
+					}
+				} catch (e) {}
+			}
+
+			return key ? jar[key] : jar;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api.call(api, key);
+		};
+		api.getJSON = function (key) {
+			return api.call({
+				json: true
+			}, key);
+		};
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.defaults = {};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));


### PR DESCRIPTION
### Description
A new banner for push notifications is displayed. It should contain following links. 
- Enable: To allow push notifications
- hide: hides the banner. Never shown again for 365 days. 
- Learn more: User is navigated to a page containing what is push notifications and how it will be used. 
- Should only be displayed for logged in users. 
- Introduce "Never show"  link. 
- ~"Hide" and "Never show" should be cross session based (multiple browsers) for the user.~

Following is a preview of the banner:
![image](https://user-images.githubusercontent.com/1382306/39845614-ba177e92-53ee-11e8-89c3-dc93247b134a.png)
