### PR TITLE
Add https configuration

### DIFF
--- a/.ebextensions/http.config
+++ b/.ebextensions/http.config
@@ -1,0 +1,89 @@
+###################################################################################################
+#### Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+####
+#### Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file
+#### except in compliance with the License. A copy of the License is located at
+####
+####     http://aws.amazon.com/apache2.0/
+####
+#### or in the "license" file accompanying this file. This file is distributed on an "AS IS"
+#### BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#### License for the specific language governing permissions and limitations under the License.
+###################################################################################################
+
+###################################################################################################
+#### This configuration file configures Nginx for Ruby Puma environments to redirect HTTP requests
+#### on port 80 to HTTPS on port 443 after you have configured your environment to support HTTPS
+#### connections:
+####
+#### Configuring Your Elastic Beanstalk Environment's Load Balancer to Terminate HTTPS:
+####  http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/configuring-https-elb.html
+####
+#### Terminating HTTPS on EC2 Instances Running Ruby Puma:
+####  http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/https-singleinstance-ruby.html#Puma
+###################################################################################################
+
+files:
+   "/opt/elasticbeanstalk/support/conf/webapp_healthd.conf":
+     owner: root
+     group: root
+     mode: "000644"
+     content: |
+       upstream my_app {
+         server unix:///var/run/puma/my_app.sock;
+       }
+
+       log_format healthd '$msec"$uri"'
+                       '$status"$request_time"$upstream_response_time"'
+                       '$http_x_forwarded_for';
+
+       server {
+         listen 80;
+         server_name _ localhost; # need to listen to localhost for worker tier
+
+         if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+           set $year $1;
+           set $month $2;
+           set $day $3;
+           set $hour $4;
+         }
+
+         access_log  /var/log/nginx/access.log  main;
+         access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+
+         location / {
+             set $redirect 0;
+             if ($http_x_forwarded_proto != "https") {
+               set $redirect 1;
+             }
+             if ($http_user_agent ~* "ELB-HealthChecker") {
+               set $redirect 0;
+             }
+             if ($redirect = 1) {
+               return 301 https://$host$request_uri;
+             }
+           proxy_pass http://my_app; # match the name of upstream directive which is defined above
+           proxy_set_header Host $host;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         }
+
+         location /assets {
+           alias /var/app/current/public/assets;
+           gzip_static on;
+           gzip on;
+           expires max;
+           add_header Cache-Control public;
+         }
+
+         location /public {
+           alias /var/app/current/public;
+           gzip_static on;
+           gzip on;
+           expires max;
+           add_header Cache-Control public;
+         }
+       }
+
+container_commands:
+  99_restart_nginx:
+    command: "service nginx restart || service nginx start"

--- a/.ebextensions/https.config
+++ b/.ebextensions/https.config
@@ -1,0 +1,80 @@
+# Dont forget to set the env variable "certdomain", and either fill in your email below or use an env variable for that too.
+# Also note that this config is using the LetsEncrypt staging server, remove the flag when ready!
+
+Resources:
+  sslSecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
+      CidrIp: 0.0.0.0/0
+
+files:
+
+  # The Nginx config forces https, and is meant as an example only.
+  /etc/nginx/conf.d/https_custom.pre:
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      server{
+        listen       443;
+        server_name localhost;
+
+        ssl                  on;
+        ssl_certificate      /etc/letsencrypt/live/ebcert/fullchain.pem;
+        ssl_certificate_key  /etc/letsencrypt/live/ebcert/privkey.pem;
+
+        ssl_session_timeout  5m;
+        ssl_protocols  TLSv1.1 TLSv1.2;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_prefer_server_ciphers   on;
+
+        if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+          set $year $1;
+          set $month $2;
+          set $day $3;
+          set $hour $4;
+        }
+
+        access_log  /var/log/nginx/access.log  main;
+
+        location / {
+          proxy_pass http://my_app;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /assets {
+          alias /var/app/current/public/assets;
+          gzip_static on;
+          gzip on;
+          expires max;
+          add_header Cache-Control public;
+        }
+
+        location /public {
+          alias /var/app/current/public;
+          gzip_static on;
+          gzip on;
+          expires max;
+          add_header Cache-Control public;
+        }
+      }
+
+
+packages:
+  yum:
+    epel-release: []
+
+container_commands:
+  10_installcertbot:
+    command: "wget https://dl.eff.org/certbot-auto;chmod a+x certbot-auto"
+  20_getcert:
+    command: "sudo ./certbot-auto certonly --debug --non-interactive --email ${certemail} --agree-tos --standalone --domains ${certdomain} --keep-until-expiring --pre-hook \"service nginx stop\""
+  30_link:
+    command: "ln -sf /etc/letsencrypt/live/${certdomain} /etc/letsencrypt/live/ebcert"
+  40_config:
+    command: "mv /etc/nginx/conf.d/https_custom.pre /etc/nginx/conf.d/https_custom.conf"

--- a/.ebextensions/securelistener-clb.config
+++ b/.ebextensions/securelistener-clb.config
@@ -1,5 +1,0 @@
-option_settings:
-  aws:elb:listener:443:
-    SSLCertificateId: arn:aws:acm:eu-west-1:918660201461:certificate/c7835d07-d99e-4ac9-b424-2c0154aa1541
-    ListenerProtocol: HTTPS
-    InstancePort: 80

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@
 # IDE and editors
 .idea/*
 .vscode/*
+
+# Ignore Python virtual environment
+env/*

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
As we are moving to a single instance based AWS Elastic Beanstalk environment for production, we need to have our own certification.

Then directly serve HTTPS from the app instance. 