### PR TITLE
Use ENV variable to use for s3 bucket

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,5 +10,5 @@ amazon:
   service: S3
   access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  bucket: "scopeabout-app-production-storage"
+  bucket: <%= ENV['PRODUCTION_DATA_S3_BUCKET'] || 'scopeabout-app-qa-storage' %>
   region: "eu-west-1"


### PR DESCRIPTION
Production stack will use the value specified for `PRODUCTION_DATA_S3_BUCKET` to use as the bucket name to store user uploading content. 

If it is not, it will default to "scopeabout-app-qa-storage" bucket (such as a QA test box). 